### PR TITLE
Add splash screen

### DIFF
--- a/src/SplashScreen.jsx
+++ b/src/SplashScreen.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function SplashScreen() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-[#0E1116] text-white">
+      <img src="/Imagens/icon_kanbanworkout.png" alt="Kanban Workout" className="w-24 h-24 mb-6" />
+      <img src="/Imagens/stiff.png" alt="Carregando" className="w-40 h-40 animate-pulse rounded-lg" />
+      <p className="mt-4 text-blue-400">Carregando...</p>
+    </div>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,31 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import SplashScreen from './SplashScreen.jsx'
 import './index.css'
 import { BrowserRouter } from 'react-router-dom'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+function Root() {
+  const [showSplash, setShowSplash] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSplash(false), 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (showSplash) {
+    return <SplashScreen />
+  }
+
+  return (
     <BrowserRouter>
       <App />
     </BrowserRouter>
-  </React.StrictMode>,
-) 
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>
+)


### PR DESCRIPTION
## Summary
- add new SplashScreen component with app icon and loading image
- show splash screen for 2 seconds on startup

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685f7025a99c8321bf5ea0a8daf9d9ae