### PR TITLE
Add login, user menu, and admin panel

### DIFF
--- a/src/AdminPage.jsx
+++ b/src/AdminPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function AdminPage() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold mb-4">Painel de Administração</h1>
+      <p className="text-gray-400">Conteúdo do admin aqui.</p>
+    </div>
+  )
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,10 @@ import { useKeenSlider } from 'keen-slider/react';
 import 'keen-slider/keen-slider.min.css';
 import { useSupabase } from './hooks/useSupabase';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import LoginPage from './LoginPage.jsx';
+import AdminPage from './AdminPage.jsx';
+import UserMenu from './UserMenu.jsx';
+import { useAuth } from './auth/AuthContext.jsx';
 
 // Tokens do Sistema de Design
 const theme = {
@@ -384,12 +388,13 @@ const KanbanWorkoutApp = ({
               {/* Gradiente para indicar overflow */}
               <div className="pointer-events-none absolute right-0 top-0 h-full w-12" style={{background: 'linear-gradient(to right, transparent, '+theme.colors.background.primary+' 80%)'}} />
             </div>
-            {/* Botão + sempre visível */}
-            <div className="flex-shrink-0 ml-2 z-10 absolute right-0 top-1/2 -translate-y-1/2">
-              <IconButton onClick={() => navigate('/biblioteca')}>
-                <Plus className="w-5 h-5 text-white" />
-              </IconButton>
-            </div>
+              {/* Botão + e menu de usuário */}
+              <div className="flex-shrink-0 ml-2 z-10 absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-2">
+                <IconButton onClick={() => navigate('/biblioteca')}>
+                  <Plus className="w-5 h-5 text-white" />
+                </IconButton>
+                <UserMenu />
+              </div>
           </div>
           {/* Seletor de Dia */}
           <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-hide day-selector">
@@ -1080,6 +1085,14 @@ const CardRestTimer = ({ duration, onFinish }) => {
 
 export default function App() {
   // Estados e handlers principais centralizados aqui
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user && window.location.pathname !== '/login') {
+      navigate('/login');
+    }
+  }, [user]);
   const getCurrentDay = () => {
     const days = ['Domingo', 'Segunda', 'Terça', 'Quarta', 'Quinta', 'Sexta', 'Sábado'];
     return days[new Date().getDay()];
@@ -1163,28 +1176,30 @@ export default function App() {
   }
             
             return (
-    <Routes>
-      <Route path="/" element={
-        <KanbanWorkoutApp
-          exercises={exercises}
-          workoutPlan={workoutPlan}
-          selectedDay={selectedDay}
-          setSelectedDay={setSelectedDay}
+      <Routes>
+        <Route path="/" element={
+          <KanbanWorkoutApp
+            exercises={exercises}
+            workoutPlan={workoutPlan}
+            selectedDay={selectedDay}
+            setSelectedDay={setSelectedDay}
                 onSetComplete={handleSetComplete}
-        />
-      } />
-      <Route path="/biblioteca" element={
-        <BibliotecaScreen
-          exercises={exercises}
-          onAddExercise={handleAddExercise}
-          onEditExercise={handleEditExercise}
-          onDeleteExercise={handleDeleteExercise}
-          selectedDay={selectedDay}
-          setSelectedDay={setSelectedDay}
-          workoutPlan={workoutPlan}
-          setWorkoutPlan={setWorkoutPlan}
-        />
-      } />
-    </Routes>
+          />
+        } />
+        <Route path="/biblioteca" element={
+          <BibliotecaScreen
+            exercises={exercises}
+            onAddExercise={handleAddExercise}
+            onEditExercise={handleEditExercise}
+            onDeleteExercise={handleDeleteExercise}
+            selectedDay={selectedDay}
+            setSelectedDay={setSelectedDay}
+            workoutPlan={workoutPlan}
+            setWorkoutPlan={setWorkoutPlan}
+          />
+        } />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/admin" element={<AdminPage />} />
+      </Routes>
   );
 }

--- a/src/LoginPage.jsx
+++ b/src/LoginPage.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from './auth/AuthContext'
+
+export default function LoginPage() {
+  const { signIn, signUp } = useAuth()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [mode, setMode] = useState('signin')
+  const [error, setError] = useState('')
+  const navigate = useNavigate()
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError('')
+    try {
+      if (mode === 'signin') {
+        await signIn(email, password)
+      } else {
+        await signUp(email, password)
+      }
+      navigate('/')
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={handleSubmit} className="bg-white/10 p-6 rounded-xl space-y-4 w-full max-w-sm">
+        <h1 className="text-xl font-bold">{mode === 'signin' ? 'Entrar' : 'Criar conta'}</h1>
+        <input
+          className="w-full p-2 rounded bg-white/5"
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+        <input
+          className="w-full p-2 rounded bg-white/5"
+          type="password"
+          placeholder="Senha"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="w-full bg-blue-500 py-2 rounded">
+          {mode === 'signin' ? 'Entrar' : 'Registrar'}
+        </button>
+        <button
+          type="button"
+          className="text-sm text-blue-300 underline"
+          onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
+        >
+          {mode === 'signin' ? 'Criar conta' : 'Fazer login'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/UserMenu.jsx
+++ b/src/UserMenu.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from './auth/AuthContext'
+
+export default function UserMenu() {
+  const { user, signOut } = useAuth()
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+
+  const handleSignOut = async () => {
+    await signOut()
+    navigate('/login')
+  }
+
+  const handleButton = () => {
+    if (!user) {
+      navigate('/login')
+    } else {
+      setOpen(!open)
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button onClick={handleButton} className="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center">
+        {user ? user.email[0].toUpperCase() : '?'}
+      </button>
+      {open && user && (
+        <div className="absolute right-0 mt-2 w-40 bg-white/10 backdrop-blur-sm rounded shadow-md p-2 text-sm">
+          <p className="px-2 py-1 truncate">{user.email}</p>
+          <button onClick={() => { setOpen(false); navigate('/admin') }} className="block w-full text-left px-2 py-1 hover:bg-white/20">Admin</button>
+          <button onClick={handleSignOut} className="block w-full text-left px-2 py-1 hover:bg-white/20">Sair</button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/auth/AuthContext.jsx
+++ b/src/auth/AuthContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { supabase } from '../supabase'
+
+const AuthContext = createContext(null)
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setUser(data.user))
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  const signIn = (email, password) =>
+    supabase.auth.signInWithPassword({ email, password })
+
+  const signUp = (email, password) =>
+    supabase.auth.signUp({ email, password })
+
+  const signOut = () => supabase.auth.signOut()
+
+  return (
+    <AuthContext.Provider value={{ user, signIn, signUp, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,7 @@ import App from './App.jsx'
 import SplashScreen from './SplashScreen.jsx'
 import './index.css'
 import { BrowserRouter } from 'react-router-dom'
+import { AuthProvider } from './auth/AuthContext.jsx'
 
 function Root() {
   const [showSplash, setShowSplash] = useState(true)
@@ -19,7 +20,9 @@ function Root() {
 
   return (
     <BrowserRouter>
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   )
 }


### PR DESCRIPTION
## Summary
- create `AuthContext` for Supabase auth
- add login screen and admin page
- show user menu beside Add button
- wrap app with AuthProvider and route to login/admin

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685f73a08e608321b27ca46ec25c474a